### PR TITLE
Bumping redstone to 0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "redstone": "0.0.6"
+    "redstone": "0.0.8"
   }
 }


### PR DESCRIPTION
The `grunt redstone` task does not work under redstone 0.0.6 due to issues with the ssh client. This should fix that.
